### PR TITLE
chore(github/workflows): remove step-security harden-runner

### DIFF
--- a/.github/workflows/gogenerate.yml
+++ b/.github/workflows/gogenerate.yml
@@ -17,11 +17,6 @@ jobs:
   generate:
     runs-on: ubuntu-latest
     steps:
-      - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
-        with:
-          egress-policy: audit
-
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:

--- a/.github/workflows/golangci.yml
+++ b/.github/workflows/golangci.yml
@@ -14,11 +14,6 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
-        with:
-          egress-policy: audit
-
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,11 +12,6 @@ jobs:
   goreleaser:
     runs-on: ubuntu-latest
     steps:
-      - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
-        with:
-          egress-policy: audit
-
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,11 +18,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
-        with:
-          egress-policy: audit
-
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
@@ -37,11 +32,6 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-      - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
-        with:
-          egress-policy: audit
-
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
@@ -75,11 +65,6 @@ jobs:
         volumes:
           - /data
     steps:
-      - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
-        with:
-          egress-policy: audit
-
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:

--- a/.github/workflows/update-indirect-dependencies.yml
+++ b/.github/workflows/update-indirect-dependencies.yml
@@ -13,11 +13,6 @@ jobs:
   update:
     runs-on: ubuntu-latest
     steps:
-      - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
-        with:
-          egress-policy: audit
-
       - id: cyspbot
         uses: chikachow/cyspbot-app-token-action@d879d41c65cc2cc85387bc0f483f33f97d9001ae # v0.0.1
 


### PR DESCRIPTION
## Summary

- Remove `step-security/harden-runner` steps from the GitHub Actions workflows.
- Rebase the existing removal branch onto the current `main`.

## Verification

- `git diff --check`
- `rg --hidden -n -g '.github/**' -g '!**/.git/**' '<<<<<<<|=======|>>>>>>>|step-security|harden-runner' .`
- `actionlint` reports the existing `.github/workflows/test.yml:81` `job.services.typesense.ports[8108]` expression typing issue, unrelated to this diff.
