### PR TITLE
ci(github/workflows): update golangci-lint

### DIFF
--- a/.github/workflows/golangci.yml
+++ b/.github/workflows/golangci.yml
@@ -22,4 +22,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1
         with:
-          version: v2.6.2
+          version: v2.12.2

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,6 +6,7 @@ linters:
     - depguard
     - exhaustruct
     - funlen
+    - goconst
     - lll
     - wsl
   settings:


### PR DESCRIPTION
## Summary
- update the golangci-lint workflow to run v2.12.2
- disable goconst explicitly because the newer linter reports low-value test fixture constants

## Verification
- go build -v .
- go test -v -coverprofile=coverage.txt -covermode=atomic -coverpkg=./... ./...
- go generate ./...
- golangci-lint run