### PR TITLE
chore: update developer tooling

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,6 +7,7 @@ linters:
     - exhaustruct
     - funlen
     - goconst
+    - gomodguard
     - lll
     - wsl
   settings:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cysp/terraform-provider-typesense
 
-go 1.25.8
+go 1.26.3
 
 require (
 	github.com/hashicorp/terraform-plugin-docs v0.25.0

--- a/go.mod
+++ b/go.mod
@@ -103,3 +103,5 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+tool github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs

--- a/main.go
+++ b/main.go
@@ -17,7 +17,7 @@ import (
 
 // Run the docs generation tool, check its repository for more information on how it works and how docs
 // can be customized.
-//go:generate go run github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs
+//go:generate go tool tfplugindocs
 
 // set by goreleaser.
 var version = "dev"

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -1,8 +1,0 @@
-//go:build tools
-
-package tools
-
-import (
-	// Documentation generation
-	_ "github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs"
-)


### PR DESCRIPTION
## Summary
- update the Go toolchain directive to 1.26.3
- move tfplugindocs from the tools.go blank-import pattern to a module tool directive
- disable deprecated golangci-lint gomodguard linter noise while retaining default all coverage

## Verification
- go test ./...
- go generate ./...
- golangci-lint cache clean
- golangci-lint run