### PR TITLE
Update Typesense Go client

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,12 +3,11 @@ module github.com/cysp/terraform-provider-typesense
 go 1.26.3
 
 require (
-	github.com/hashicorp/terraform-plugin-docs v0.25.0
 	github.com/hashicorp/terraform-plugin-framework v1.19.0
 	github.com/hashicorp/terraform-plugin-go v0.31.0
 	github.com/hashicorp/terraform-plugin-testing v1.16.0
 	github.com/stretchr/testify v1.11.1
-	github.com/typesense/typesense-go v1.1.0
+	github.com/typesense/typesense-go/v3 v3.2.0
 )
 
 require (
@@ -50,6 +49,7 @@ require (
 	github.com/hashicorp/logutils v1.0.0 // indirect
 	github.com/hashicorp/terraform-exec v0.25.2 // indirect
 	github.com/hashicorp/terraform-json v0.27.3-0.20260213134036-298b8f6b673a // indirect
+	github.com/hashicorp/terraform-plugin-docs v0.25.0 // indirect
 	github.com/hashicorp/terraform-plugin-log v0.10.0 // indirect
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.40.0 // indirect
 	github.com/hashicorp/terraform-registry-address v0.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -201,8 +201,8 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-github.com/typesense/typesense-go v1.1.0 h1:QocehDarVXRArMIosPIdawiVFZZbnRkPJxwnAGOFkzw=
-github.com/typesense/typesense-go v1.1.0/go.mod h1:KcPODU7ltrcUFC/gygMTkAAfZ9M8/q6ayrdl1MnE1kI=
+github.com/typesense/typesense-go/v3 v3.2.0 h1:pmrq46PkxhS0xowPMCnfOcBYCbIfMESas45py4jk8LQ=
+github.com/typesense/typesense-go/v3 v3.2.0/go.mod h1:Jx4PAXe3jRx6sc032nhN9Aj+OvMoPtQJW6p1a6H4Zeg=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=

--- a/internal/provider/key_model_request.go
+++ b/internal/provider/key_model_request.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
-	typesense_api "github.com/typesense/typesense-go/typesense/api"
+	typesense_api "github.com/typesense/typesense-go/v3/typesense/api"
 )
 
 func (model *KeyModel) ToAPIKeySchema(ctx context.Context) (typesense_api.ApiKeySchema, diag.Diagnostics) {

--- a/internal/provider/key_model_request_test.go
+++ b/internal/provider/key_model_request_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/stretchr/testify/assert"
-	typesense_api "github.com/typesense/typesense-go/typesense/api"
+	typesense_api "github.com/typesense/typesense-go/v3/typesense/api"
 )
 
 func TestKeyModelToAPIKeySchema(t *testing.T) {

--- a/internal/provider/key_model_response.go
+++ b/internal/provider/key_model_response.go
@@ -6,7 +6,7 @@ import (
 	"github.com/cysp/terraform-provider-typesense/internal/provider/util"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	typesense_api "github.com/typesense/typesense-go/typesense/api"
+	typesense_api "github.com/typesense/typesense-go/v3/typesense/api"
 )
 
 func (model *KeyModel) ReadFromResponse(ctx context.Context, apiKey *typesense_api.ApiKey) diag.Diagnostics {

--- a/internal/provider/key_model_response_test.go
+++ b/internal/provider/key_model_response_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/stretchr/testify/assert"
-	typesense_api "github.com/typesense/typesense-go/typesense/api"
+	typesense_api "github.com/typesense/typesense-go/v3/typesense/api"
 )
 
 func TestKeyModelReadFromResponse(t *testing.T) {

--- a/internal/provider/key_resource.go
+++ b/internal/provider/key_resource.go
@@ -8,7 +8,7 @@ import (
 	"github.com/cysp/terraform-provider-typesense/internal/provider/util"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
-	"github.com/typesense/typesense-go/typesense"
+	"github.com/typesense/typesense-go/v3/typesense"
 )
 
 var (

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/provider"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
-	"github.com/typesense/typesense-go/typesense"
+	"github.com/typesense/typesense-go/v3/typesense"
 )
 
 var _ provider.Provider = (*TypesenseProvider)(nil)

--- a/internal/provider/provider_data.go
+++ b/internal/provider/provider_data.go
@@ -1,7 +1,7 @@
 package provider
 
 import (
-	"github.com/typesense/typesense-go/typesense"
+	"github.com/typesense/typesense-go/v3/typesense"
 )
 
 type TypesenseProviderData struct {


### PR DESCRIPTION
## Summary
- update the Typesense Go client from v1.1.0 to the current stable v3.2.0 module path
- adjust provider imports to use github.com/typesense/typesense-go/v3
- tidy module checksums

## Validation
- go test ./...

## Notes
- The provider only uses API key client surfaces, which remain source-compatible with v3.2.0.