### PR TITLE
fix: default collection field attributes

### DIFF
--- a/internal/provider/collection_resource_schema.go
+++ b/internal/provider/collection_resource_schema.go
@@ -4,9 +4,11 @@ import (
 	"context"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
@@ -37,27 +39,39 @@ func (model *CollectionModel) ResourceSchemaAttributes(_ context.Context) map[st
 					},
 					"facet": schema.BoolAttribute{
 						Optional: true,
+						Computed: true,
+						Default:  booldefault.StaticBool(false),
 					},
 					"index": schema.BoolAttribute{
 						Optional: true,
+						Computed: true,
+						Default:  booldefault.StaticBool(true),
 					},
 					"infix": schema.BoolAttribute{
 						Optional: true,
+						Computed: true,
+						Default:  booldefault.StaticBool(false),
 					},
 					"locale": schema.StringAttribute{
 						Optional: true,
+						Computed: true,
+						Default:  stringdefault.StaticString(""),
 					},
 					"num_dim": schema.Int64Attribute{
 						Optional: true,
 					},
 					"optional": schema.BoolAttribute{
 						Optional: true,
+						Computed: true,
+						Default:  booldefault.StaticBool(false),
 					},
 					"reference": schema.StringAttribute{
 						Optional: true,
 					},
 					"sort": schema.BoolAttribute{
 						Optional: true,
+						Computed: true,
+						Default:  booldefault.StaticBool(false),
 					},
 				},
 			},

--- a/internal/provider/collection_resource_test.go
+++ b/internal/provider/collection_resource_test.go
@@ -1,0 +1,84 @@
+package provider_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+)
+
+func TestAccCollectionResourceDefaults(t *testing.T) {
+	t.Parallel()
+
+	collectionName := "testacc_" + acctest.RandStringFromCharSet(8, acctest.CharSetAlphaNum)
+	defaultConfig := fmt.Sprintf(`
+	resource "typesense_collection" "test" {
+		name = %[1]q
+
+		fields = [
+			{
+				name = "title"
+				type = "string"
+			},
+		]
+	}
+	`, collectionName)
+	facetConfig := fmt.Sprintf(`
+	resource "typesense_collection" "test" {
+		name = %[1]q
+
+		fields = [
+			{
+				name = "title"
+				type = "string"
+				facet = true
+			},
+		]
+	}
+	`, collectionName)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: defaultConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("typesense_collection.test", "fields.0.facet", "false"),
+					resource.TestCheckResourceAttr("typesense_collection.test", "fields.0.index", "true"),
+					resource.TestCheckResourceAttr("typesense_collection.test", "fields.0.infix", "false"),
+					resource.TestCheckResourceAttr("typesense_collection.test", "fields.0.locale", ""),
+					resource.TestCheckResourceAttr("typesense_collection.test", "fields.0.optional", "false"),
+					resource.TestCheckResourceAttr("typesense_collection.test", "fields.0.sort", "false"),
+				),
+			},
+			{
+				Config: defaultConfig,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("typesense_collection.test", plancheck.ResourceActionNoop),
+					},
+				},
+			},
+			{
+				Config: facetConfig,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("typesense_collection.test", plancheck.ResourceActionReplace),
+					},
+				},
+				Check: resource.TestCheckResourceAttr("typesense_collection.test", "fields.0.facet", "true"),
+			},
+			{
+				Config: defaultConfig,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("typesense_collection.test", plancheck.ResourceActionReplace),
+					},
+				},
+				Check: resource.TestCheckResourceAttr("typesense_collection.test", "fields.0.facet", "false"),
+			},
+		},
+	})
+}


### PR DESCRIPTION
## Summary
- default server-populated collection field attributes in the Terraform schema
- cover minimal collection convergence and explicit default removal with an acceptance test

## Tests
- go test ./...
- TF_ACC=1 TYPESENSE_URL=http://127.0.0.1:8108 TYPESENSE_API_KEY=12345 go test ./internal/provider -run TestAccCollectionResourceDefaults -count=1 -v